### PR TITLE
Fix/intel pin/indices

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,3 @@
 #Build and pin directories
 /build
 /pin_dir
-
-#IDE files
-/.idea

--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,6 @@
 #Build and pin directories
 /build
 /pin_dir
+
+#IDE files
+/.idea

--- a/pin_tracing/ImemROIThreads.cpp
+++ b/pin_tracing/ImemROIThreads.cpp
@@ -501,24 +501,24 @@ VOID RecordMemScattered(IMULTI_ELEMENT_OPERAND* memOpInfo, THREADID threadid) {
 
       //READ
       if ((rw == 0) || (rw == 2) ) {
-	Mcnt[j]++;
-	//Mbytes[j] += bsize;  
+	Mcnt[i]++;
+	//Mbytes[i] += bsize;
 	tent.type = (unsigned short) 0;
   
-	memcpy(ptrace[j], &tent, sizeof(trace_entry_t));
-	ptrace[j] += 1;
-	drtrace_write(fptrace[j], &btrace[j][0], &ptrace[j], 0, j);	
+	memcpy(ptrace[i], &tent, sizeof(trace_entry_t));
+	ptrace[i] += 1;
+	drtrace_write(fptrace[i], &btrace[i][0], &ptrace[i], 0, i);
       }
 
       //WRITE
       if ((rw == 1) || (rw == 2) ) {
-	Mcnt[j]++;
-	//Mbytes[j] += bsize;  
+	Mcnt[i]++;
+	//Mbytes[i] += bsize;
 	tent.type = (unsigned short) 1;
   
-	memcpy(ptrace[j], &tent, sizeof(trace_entry_t));
-	ptrace[j] += 1;
-	drtrace_write(fptrace[j], &btrace[j][0], &ptrace[j], 0, j);
+	memcpy(ptrace[i], &tent, sizeof(trace_entry_t));
+	ptrace[i] += 1;
+	drtrace_write(fptrace[i], &btrace[i][0], &ptrace[i], 0, i);
       }
       
     }

--- a/pin_tracing/ImemROIThreadsRange.cpp
+++ b/pin_tracing/ImemROIThreadsRange.cpp
@@ -35,9 +35,6 @@ INT64 maxbytes (1LL<<37); //128GiB
 #define NBUFS (1024)
 INT32 numThreads = 0;
 
-#define PADSIZE 56 // 64 byte line size: 64-8
-#define NBUFS (1024)
-
 //FROM DR SOURCE
 //DR trace
 typedef uintptr_t addr_t;


### PR DESCRIPTION
1- Removed duplicated #include commands in ImemROIThreadsRange.cpp.

2- Replace scattered element index (j) with ROI bucket index (i) when
accessing per-ROI arrays (Mcnt, ptrace, fptrace, btrace) in RecordMemScattered() method of ImemROIThreads.cpp.